### PR TITLE
Compatible with react-native packager

### DIFF
--- a/int64-buffer.js
+++ b/int64-buffer.js
@@ -267,4 +267,4 @@ var Uint64BE, Int64BE;
     return !!val && "[object Array]" == Object.prototype.toString.call(val);
   }
 
-}(this || {});
+}(typeof exports === 'object' && typeof exports.nodeName !== 'string' ? exports : (this || {}));


### PR DESCRIPTION
In React Native the `this` context of the CommonJS module body isn't set to `exports`. This means that the expression at the bottom doesn't have the intended effect and `module.exports` ends up as an empty object.

This variant should support all existing use cases but also works as expected in React Native.

See: https://github.com/facebook/react-native/issues/2862