### PR TITLE
add type definitions for Typescript projects

### DIFF
--- a/int64-buffer.d.ts
+++ b/int64-buffer.d.ts
@@ -1,15 +1,20 @@
 // TypeScript type definitions
 declare abstract class Int64 
 {
+	type ArrayType = Uint8Array | ArrayBuffer | number[];
+
 	constructor(value?: number);
 	constructor(high: number, low: number);
 	constructor(value: string, radix?: number);
-	constructor(array: Uint8Array);
-	constructor(array: ArrayBuffer);
-	constructor(array: number[]);
-	constructor(buf: Buffer, offset?: number, value?: number);
+	constructor(buf: Buffer);
+	constructor(buf: Buffer, offset: number, value?: number);
 	constructor(buf: Buffer, offset: number, high: number, low: number);
 	constructor(buf: Buffer, offset: number, value: string, radix?: number);
+	constructor(array: ArrayType);
+	constructor(array: ArrayType, offset: number, value?: number);
+	constructor(array: ArrayType, offset: number, high: number, low: number);
+	constructor(array: ArrayType, offset: number, value: string, radix?: number);
+
 	toNumber(): number;
 	toJSON(): number;
 	toString(radix?: number): string;

--- a/int64-buffer.d.ts
+++ b/int64-buffer.d.ts
@@ -1,0 +1,27 @@
+// TypeScript type definitions
+declare abstract class Int64 
+{
+	constructor(value?: number);
+	constructor(high: number, low: number);
+	constructor(value: string, radix?: number);
+	constructor(array: Uint8Array);
+	constructor(array: ArrayBuffer);
+	constructor(array: number[]);
+	constructor(buf: Buffer, offset?: number, value?: number);
+	constructor(buf: Buffer, offset: number, high: number, low: number);
+	constructor(buf: Buffer, offset: number, value: string, radix?: number);
+	toNumber(): number;
+	toJSON(): number;
+	toString(radix?: number): string;
+	toBuffer(raw?: boolean): Buffer;
+	toArrayBuffer(raw?: boolean): ArrayBuffer;
+	toArray(raw?: boolean): number[];
+}
+export declare class Int64BE extends Int64 
+{
+	static isInt64BE(obj: any): obj is Int64BE;
+}
+export declare class Uint64BE extends Int64 
+{
+	static isUint64BE(obj: any): obj is Uint64BE;
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   ],
   "license": "MIT",
   "main": "int64-buffer.js",
+  "typings": "int64-buffer.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kawanet/int64-buffer.git"


### PR DESCRIPTION
Greetings,

Thanks for the module! I've started to use it in a Typescript project, and was wondering if I could add a Typescript definition file (here in the pull request) directly to your module.  I already wrote it for my project, putting it here so ideally everyone can benefit.

Also, hopefully the code agrees with your intended module API.