### PR TITLE
Correcting a Typescript def error

### DIFF
--- a/int64-buffer.d.ts
+++ b/int64-buffer.d.ts
@@ -1,8 +1,9 @@
 // TypeScript type definitions
+
+type ArrayType = Uint8Array | ArrayBuffer | number[];
+
 declare abstract class Int64 
 {
-	type ArrayType = Uint8Array | ArrayBuffer | number[];
-
 	constructor(value?: number);
 	constructor(high: number, low: number);
 	constructor(value: string, radix?: number);


### PR DESCRIPTION
Sorry, I swore I was using the Typescript type-def that I provided.  Apparently I was using the version before I made the type alias, and only just caught an error after updating to your latest int64-buffer version.

This fixes the error: apparently type aliases cannot exist inside a class.

Thanks for integrating the .d.ts def :)